### PR TITLE
Fix typo: msgErr => errMsg

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -169,7 +169,7 @@ getCss = (variables, styles, verbose, done) ->
 
     benchmark.start 'less-compile'
     less.render tmp, compress: true, (err, result) ->
-      if err then return done(msgErr 'Error processing LESS -> CSS', err)
+      if err then return done(errMsg 'Error processing LESS -> CSS', err)
 
       try
         css = result.css


### PR DESCRIPTION
I got this error when using aglio to generate documents.
```
UnhandledPromiseRejectionWarning: ReferenceError: msgErr is not defined
    at /home/linuxbrew/.linuxbrew/lib/node_modules/aglio/node_modules/aglio-theme-olio/lib/main.js:218:11
    at /home/linuxbrew/.linuxbrew/lib/node_modules/aglio/node_modules/less/lib/less/render.js:26:35
    at /home/linuxbrew/.linuxbrew/lib/node_modules/aglio/node_modules/less/lib/less/parse.js:62:33
    at ImportVisitor.finish [as _finish] (/home/linuxbrew/.linuxbrew/lib/node_modules/aglio/node_modules/less/lib/less/parser/parser.js:180:2
8)
```